### PR TITLE
Fix read timeout

### DIFF
--- a/lan/net.go
+++ b/lan/net.go
@@ -78,7 +78,11 @@ func Receive(port uint32) (host string, msg *Message, err error) {
 		return "", nil, err
 	}
 
-	if err := conn.SetReadDeadline(time.Now().Add(ReadTimeout)); err != nil {
+	var timeout time.Time
+	if ReadTimeout != 0 {
+		timeout = time.Now().Add(ReadTimeout)
+	}
+	if err := conn.SetReadDeadline(timeout); err != nil {
 		return "", nil, fmt.Errorf("unable to set read deadline: %s", err)
 	}
 


### PR DESCRIPTION
Because the read timeout was not checking for a zero value, using the
default value was causing immediate timeouts on read rather than
blocking while waiting for packets as intended.